### PR TITLE
Don't backup phone numbers not in contacts

### DIFF
--- a/src/phonebackupv4/MainScreen.java
+++ b/src/phonebackupv4/MainScreen.java
@@ -167,7 +167,7 @@ public class MainScreen extends javax.swing.JFrame {
                                         d.getInt("duration"));
 
                         if (!contactExists(contacts,
-                                contact)) {
+                                contact) && !contact.getName().isEmpty()) {
                             contacts.add(contact);
                         }
                         phoneCalls.add(phoneCall);


### PR DESCRIPTION
If the name of the phone number is empty, then don't backup the phone number.